### PR TITLE
DA-178 Add email config values

### DIFF
--- a/config.ini.php
+++ b/config.ini.php
@@ -11,6 +11,19 @@ tables_prefix = "matomo_"
 proxy_client_headers[] = "HTTP_X_FORWARDED_FOR"
 salt = "$SALT"
 trusted_hosts[] = "$TRUSTED_HOSTS"
+login_password_recovery_email_address = $SMTP_NOREPLY_ADDRESS
+login_password_recovery_replyto_email_address = $SMTP_NOREPLY_ADDRESS
+noreply_email_address = $SMTP_NOREPLY_ADDRESS
+noreply_email_name = "Matomo"
+
+[mail]
+transport = "smtp"
+port = $SMTP_PORT
+host = $SMTP_HOST
+type = $SMTP_AUTH_TYPE
+username = $SMTP_USER
+password = $SMTP_PASSWORD
+encryption = "tls"
 
 [PluginsInstalled]
 PluginsInstalled[] = "Diagnostics"


### PR DESCRIPTION
I noticed that Matomo isn't sending password reset emails, and I think this PR might fix the problem. This adds three new fields to `config.ini.php`:

`noreply_email_address`
`login_password_recovery_email_address`
`login_password_recovery_replyto_email_address`

I initially set these to be ENV variables, but I'm open to discussion if hardcoding is preferable.

Here's the documentation that informed this work: https://matomo.org/faq/troubleshooting/faq_34856/

And the corresponding JIRA ticket: https://mitlibraries.atlassian.net/browse/DA-178
