### PR TITLE
Fix publish target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,6 @@ publish: ## Promote the current staging build to production
 	docker pull $(ECR_REGISTRY)/analytics-stage:latest
 	docker tag $(ECR_REGISTRY)/analytics-stage:latest $(ECR_REGISTRY)/analytics-prod:latest
 	docker tag $(ECR_REGISTRY)/analytics-stage:latest $(ECR_REGISTRY)/analytics-prod:$(DATETIME)
-		
-promote:
-	$$(aws ecr get-login --no-include-email --region us-east-1)
 	docker push $(ECR_REGISTRY)/analytics-prod:latest
 	docker push $(ECR_REGISTRY)/analytics-prod:$(DATETIME)
 	aws ecs update-service --cluster analytics-prod-cluster --service analytics-prod --region us-east-1 --force-new-deployment


### PR DESCRIPTION
The existing promote target won't work because the datetime variable is
always going to be different from when the image was tagged using the
publish target. Also, pulling the stage image and then tagging and
pushing the prod image should all be run in the same target, otherwise
you cannot guarantee that what you have tagged locally as prod is the
same as what is currently in staging.

This commit combines what was the publish and promote targets into a
single publish target.