### PR TITLE
Update version and clarify documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM matomo:4.12.0
+FROM matomo:4.13.1
 
 # Add the EnvironmentVariables plugin
 COPY ./files/plugin-EnvironmentVariables-4.0.1/ /var/www/html/plugins/EnvironmentVariables

--- a/docs/HowTos/HOWTO-compare-ini-files.md
+++ b/docs/HowTos/HOWTO-compare-ini-files.md
@@ -1,0 +1,29 @@
+# How-to instructions
+
+Detailed how-to instructions to compare the running copy of config.ini.php to the version in this repo.
+
+## Command line access
+
+1. Log in to the [AWS Console](https://mitlib.awsapps.com/start#/) to retrieve your `Command line or programmatic access` credentials.
+1. Copy the appropriate OS information and paste it into your local terminal.
+1. Log in to the docker container in ECS - See [docker-matomo/docs/HowTos/HOWTO-miscellaneous.md](https://github.com/MITLibraries/docker-matomo/blob/main/docs/HowTos/HOWTO-miscellaneous.md) for instructions.
+1. Run the backup script:
+
+   ```bash
+   /usr/local/bin/backup-data.sh
+   ```
+
+1. Access the EFS mounted copy of config.ini.php.
+
+   ```bash
+   more /mnt/efs/config/config/config.ini.php # Hit space until all content is revealed
+   ```
+
+1. Copy/paste this information into a new file in your local editor and save as dev.ini (or other name of your choice).
+1. Compare the 2 files for any differences.  Ignore any changes in these sections:
+   * [database]
+   * [Tracker]
+   * [mail]
+   * **NB** Comment lines are not copied to the running/backup copy of config.ini.php.
+1. Verify information in the [General] section. **NB** Sometimes the order of various settings will change between Matomo versions
+1. Copy any differences in [Plugins] and [PluginsInstalled] to the repo copy of config.ini.php and save.

--- a/docs/HowTos/HOWTO-miscellaneous.md
+++ b/docs/HowTos/HOWTO-miscellaneous.md
@@ -15,7 +15,7 @@ The container-based Matomo installation requires a walk through of the web UI to
 
 ## Troubleshooting
 
-It **is** possible to SSH into the Matomo container while it is running in ECS:  `Ensure you have the latest Session Manager plugin installed if you have errors or no output to the following command`
+It **is** possible to SSH into the Matomo container while it is running in ECS:  **Ensure you have the latest Session Manager plugin installed if you have errors or no output to the following command:**
 
 ```bash
 aws ecs execute-command --region {name-of-the-region} --cluster {name-of-the-cluster} --task {task number} --command "/bin/bash" --interactive

--- a/docs/HowTos/HOWTO-miscellaneous.md
+++ b/docs/HowTos/HOWTO-miscellaneous.md
@@ -15,10 +15,36 @@ The container-based Matomo installation requires a walk through of the web UI to
 
 ## Troubleshooting
 
-It **is** possible to SSH into the Matomo container while it is running in ECS:
+It **is** possible to SSH into the Matomo container while it is running in ECS:  `Ensure you have the latest Session Manager plugin installed if you have errors or no output to the following command`
 
 ```bash
 aws ecs execute-command --region {name-of-the-region} --cluster {name-of-the-cluster} --task {task number} --command "/bin/bash" --interactive
 ```
 
 This can be used for quick checks of the `config.ini.php` file to see if actions in the UI made any modifications. This is also required for doing major version upgrades of Matomo (e.g. from 3.x to 4.x).
+
+To retrieve the **task number** value for the command:
+
+* Open the AWS Dev1 console in your browser
+* Navigate to ECS (Elastic Container Service)
+* Click on `matomo-ecs-dev-cluster` (This is also the cluster name for the above command)
+* Click on the `Tasks` tab
+* Copy the Task number from the list (there should be only one)
+
+OR
+
+```bash
+aws ecs list-clusters | grep matomo
+aws ecs list-tasks --cluster matomo-ecs-dev-cluster (or result from previous command)
+# The task number is the 32 character hex string at the end of the line
+```
+
+## Reset 2-Factor auth
+
+If we ever need to reset the 2FA configuration for a user, this is the command to run on the CLI of the container
+
+```bash
+./console twofactorauth:disable-2fa-for-user --login=yourlogin
+```
+
+See [FAQ_27248](https://matomo.org/faq/how-to/faq_27248/) for more details.

--- a/files/backup-data.sh
+++ b/files/backup-data.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-/bin/cp -r /var/www/html/config /mnt/efs/config
+/bin/cp -r /var/www/html/config/ /mnt/efs/config/
 /bin/cp -r /var/www/html/misc/user /mnt/efs/misc_user
-/bin/cp -r /var/www/html/js /mnt/efs/js
+/bin/cp -r /var/www/html/js/ /mnt/efs/js/
 /bin/cp -r /var/www/html/matomo.js /mnt/efs/matomo.js
 /bin/cp -r /var/www/html/piwik.js /mnt/efs/piwik.js

--- a/files/config.ini.php
+++ b/files/config.ini.php
@@ -11,11 +11,17 @@ datatable_archiving_maximum_rows_referrers = 5000
 ; maximum number of rows for any of the Referers subtable (search engines by keyword, keyword by campaign, etc.), and Custom variables values
 datatable_archiving_maximum_rows_subtable_referrers = 5000
 
+; maximum number of rows for the User ID report
+datatable_archiving_maximum_rows_userid_users = 5000
+
 ; maximum number of rows for any of the Actions tables (pages, downloads, outlinks)
 datatable_archiving_maximum_rows_actions = 5000
 
 ; maximum number of rows for pages in categories (sub pages, when clicking on the + for a page category)
 datatable_archiving_maximum_rows_subtable_actions = 5000
+
+; maximum number of rows for the Site Search table
+ datatable_archiving_maximum_rows_site_search = 5000
 
 ; maximum number of rows for any of the Events tables (Categories, Actions, Names)
 datatable_archiving_maximum_rows_events = 5000
@@ -23,15 +29,10 @@ datatable_archiving_maximum_rows_events = 5000
 ; maximum number of rows for sub-tables of the Events tables (eg. for the subtables Categories>Actions or Categories>Names).
 datatable_archiving_maximum_rows_subtable_events = 100
 
-; maximum number of rows for the Site Search table
- datatable_archiving_maximum_rows_site_search = 5000
-
-; maximum number of rows for the User ID report
-datatable_archiving_maximum_rows_userid_users = 5000
-
 [mail]
 
 [Plugins]
+Plugins[] = "CoreVue"
 Plugins[] = "CorePluginsAdmin"
 Plugins[] = "CoreAdminHome"
 Plugins[] = "CoreHome"
@@ -71,7 +72,6 @@ Plugins[] = "CoreConsole"
 Plugins[] = "ScheduledReports"
 Plugins[] = "UserCountryMap"
 Plugins[] = "Live"
-Plugins[] = "CustomVariables"
 Plugins[] = "PrivacyManager"
 Plugins[] = "ImageGraph"
 Plugins[] = "Annotations"
@@ -86,7 +86,10 @@ Plugins[] = "DevicePlugins"
 Plugins[] = "Heartbeat"
 Plugins[] = "Intl"
 Plugins[] = "Tour"
+Plugins[] = "PagePerformance"
+Plugins[] = "CustomDimensions"
 Plugins[] = "MobileAppMeasurable"
+Plugins[] = "CustomVariables"
 Plugins[] = "EnvironmentVariables"
 
 [PluginsInstalled]
@@ -150,3 +153,7 @@ PluginsInstalled[] = "Marketplace"
 PluginsInstalled[] = "ProfessionalServices"
 PluginsInstalled[] = "Tour"
 PluginsInstalled[] = "EnvironmentVariables"
+PluginsInstalled[] = "CoreVue"
+PluginsInstalled[] = "MobileAppMeasurable"
+PluginsInstalled[] = "PagePerformance"
+PluginsInstalled[] = "CustomDimensions"


### PR DESCRIPTION
### What does this PR do?

Upgrades Matomo to version 4.13.1 and adds/clarifies documentation for the engineer performing the Matomo upgrade.

### Helpful background context

* Increment the version to upgrade Matomo to 4.13.1
* Update documentation for clarity
* Add detailed upgrade steps
  * Clarify how to compare ini files
  * Clarify container/service deployment
* Experimented with syntax changes in backup script
   * Trailing slashes had no effect on output
    * There are still nested folders in EFS
* Add 2FA reset instructions
  * This includes the cli command to reset 2FA for a user account (and
  * points to the full documenation at matomo.org).

Changes to be committed:
	modified:   Dockerfile
	new file:   docs/HowTos/HOWTO-compare-ini-files.md
	modified:   docs/HowTos/HOWTO-matomo-upgrade.md
	modified:   docs/HowTos/HOWTO-miscellaneous.md
	modified:   files/backup-data.sh
	modified:   files/config.ini.php

### How can a reviewer manually see the effects of these changes?

Updated Docker image in ECR
Logging into Matomo in Dev1 will show version 4.13.1

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

[IN-364](https://mitlibraries.atlassian.net/browse/INFRA-364)

### Developer

- [X] All new ENV is documented in README (or there is none)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes


[IN-364]: https://mitlibraries.atlassian.net/browse/IN-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ