### PR TITLE
Update to Matomo 5.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM matomo:5.1.0
+FROM matomo:5.1.1
 
 # Add the EnvironmentVariables plugin
 COPY ./files/plugin-EnvironmentVariables-5.0.0/ /var/www/html/plugins/EnvironmentVariables

--- a/files/config.ini.php
+++ b/files/config.ini.php
@@ -1,6 +1,8 @@
 ; <?php exit; ?> DO NOT REMOVE THIS LINE
 ; file automatically generated or modified by Matomo; you can manually override the default values in global.ini.php by redefining them in this file.
 [database]
+schema = Mariadb
+charset = utf8mb4
 
 [General]
 proxy_client_headers[] = "HTTP_X_FORWARDED_FOR"


### PR DESCRIPTION
How this addresses that need:


Side effects of this change:
None.

Relevant ticket(s):


### What does this PR do?

* Update the Dockerfile to pull the 5.1.1 version of the Matomo container
* Update the config.ini.php file to reflect the fact that we are using Maria DB (not MySQL) for the database
* Update the config.ini.php file to fix the issue that the Matomo System Check page did not recognize that the database had already enabled the utf8mb4 character set.

### Helpful background context

UXWS requested an upgrade to our instance of Matomo. In the process of testing the upgrade in Dev1, I discovered that there was an issue with both the database schema configuration and the database character set configuration. Both of those issues were minor and are addressed with the changes to the `config.ini.php` file.

### How can a reviewer manually see the effects of these changes?

This updated container is deployed to Dev1 so the reviewer can log in to the Dev1 instance of Matomo (https://matomo-ecs-dev.dev1.mitlibrary.net:8443) and verify that the reported version is correct and that the System Check page only has the Geolocation warning (that's a warning that we don't care about).

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

* [INFRA-471](https://mitlibraries.atlassian.net/browse/INFRA-471)

### Developer

- [n/a] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes


[INFRA-471]: https://mitlibraries.atlassian.net/browse/INFRA-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ