### PR TITLE
Update to 5.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM matomo:5.1.1
+FROM matomo:5.1.2
 
 # Add the EnvironmentVariables plugin
-COPY ./files/plugin-EnvironmentVariables-5.0.0/ /var/www/html/plugins/EnvironmentVariables
+COPY ./files/plugin-EnvironmentVariables-5.0.2/ /var/www/html/plugins/EnvironmentVariables
 
 # Add the CustomVariables plugin
 COPY ./files/plugin-CustomVariables-5.0.2/ /var/www/html/plugins/CustomVariables

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Merge a PR to `main` to build, tag, and push the container to Stage-Workloads. A
 
 ## Implementation notes
 
-For detailed instructions on initial setup, migration, database upgrades, and application upgrades, see [docs/HOWTO.md](./docs/HOWTO.md).
+For detailed instructions on initial setup, migration, database upgrades, and application upgrades, check the [HowTos](./docs/HowTos/) folder.
 
 ### Configuration Management
 

--- a/files/plugin-EnvironmentVariables-5.0.2/CHANGELOG.md
+++ b/files/plugin-EnvironmentVariables-5.0.2/CHANGELOG.md
@@ -1,0 +1,19 @@
+## Changelog
+
+### 5.0.2 - 2024-10-21
+- Documentation updated to hard code config
+
+### 5.0.1
+-  Added plugin category for Marketplace
+
+### 5.0.0
+- Compatibility with Matomo 5
+
+### 4.0.1
+- Compatibility with PHP DI 6
+
+### 4.0.0
+- Compatibility with Matomo 4
+
+### 3.0.0
+ * Initial version

--- a/files/plugin-EnvironmentVariables-5.0.2/EnvironmentVariables.php
+++ b/files/plugin-EnvironmentVariables-5.0.2/EnvironmentVariables.php
@@ -1,0 +1,44 @@
+<?php 
+/**
+ * Plugin Name: Environment Variables (Matomo Plugin)
+ * Plugin URI: http://plugins.matomo.org/EnvironmentVariables
+ * Description: Allows you to specify Matomo config in environment variables instead of the config file.
+ * Author: Matomo
+ * Author URI: https://matomo.org
+ * Version: 5.0.2
+ */
+?><?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\EnvironmentVariables;
+
+ 
+if (defined( 'ABSPATH')
+&& function_exists('add_action')) {
+    $path = '/matomo/app/core/Plugin.php';
+    if (defined('WP_PLUGIN_DIR') && WP_PLUGIN_DIR && file_exists(WP_PLUGIN_DIR . $path)) {
+        require_once WP_PLUGIN_DIR . $path;
+    } elseif (defined('WPMU_PLUGIN_DIR') && WPMU_PLUGIN_DIR && file_exists(WPMU_PLUGIN_DIR . $path)) {
+        require_once WPMU_PLUGIN_DIR . $path;
+    } else {
+        return;
+    }
+    add_action('plugins_loaded', function () {
+        if (function_exists('matomo_add_plugin')) {
+            matomo_add_plugin(__DIR__, __FILE__, true);
+        }
+    });
+}
+
+class EnvironmentVariables extends \Piwik\Plugin
+{
+    public function isTrackerPlugin()
+    {
+        return true;
+    }
+}

--- a/files/plugin-EnvironmentVariables-5.0.2/README.md
+++ b/files/plugin-EnvironmentVariables-5.0.2/README.md
@@ -1,0 +1,43 @@
+# Matomo EnvironmentVariables Plugin
+
+## Description
+
+Override any Matomo config with environment variables. To overwrite any setting simply specify an environment variable in the following format:
+
+```
+MATOMO_$CATEGORY_$SETTING
+```
+
+For example to overwrite the database username and password which is usually defined in the `config/config.ini.php` like this:
+
+```ini
+[database]
+username = "root"
+password = "secure"
+```
+
+using environment variables like this:
+
+```bash
+export MATOMO_DATABASE_USERNAME=root
+export MATOMO_DATABASE_PASSWORD=secure
+```
+
+### Known issues:
+* Configuration arrays are currently not supported, for example you cannot define which `Plugins[]` should be loaded.
+* At some point your Matomo may save/write the config file, for example when changing certain settings through the UI such as the trusted hosts. In this case, the currently read environment variables will be saved in the config file.
+* If this plugin is used with PHP-FPM, for example in combination with NGINX, PHP-FPM will not have access to the environment variables by default. The pool used by PHP-FPM must either explicit define which ENVs should be exposed, or set `clear_env = no` in `/etc/php7/php-fpm.f/<pool>.conf`.
+* When defining the database credentials as environment variables, you may have to hard code the configs indicating that this plugin is activated, like the following:
+```
+[PluginsInstalled]
+PluginsInstalled[] = "EnvironmentVariables"
+
+[Plugins]
+Plugins[] = "EnvironmentVariables"
+```
+Another option is to use the following console commands during the deployment process:
+```
+./console config:set 'Plugins.Plugins[]="EnvironmentVariables"'
+./console config:set 'PluginsInstalled.PluginsInstalled[]="EnvironmentVariables"'
+```
+

--- a/files/plugin-EnvironmentVariables-5.0.2/config/config.php
+++ b/files/plugin-EnvironmentVariables-5.0.2/config/config.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+return [
+    'Piwik\Config' => \Piwik\DI::decorate(function ($previous, \Piwik\Container\Container $c) {
+        $settings = $c->get(\Piwik\Application\Kernel\GlobalSettingsProvider::class);
+
+        $ini = $settings->getIniFileChain();
+        $all = $ini->getAll();
+        foreach ($all as $category => $settings) {
+            $categoryEnvName = 'MATOMO_' . strtoupper($category);
+            foreach ($settings as $settingName => $value) {
+                $settingEnvName  = $categoryEnvName . '_' .strtoupper($settingName);
+
+                $envValue = getenv($settingEnvName);
+                if ($envValue !== false) {
+                    $general = $previous->$category;
+                    $general[$settingName] = $envValue;
+                    $previous->$category = $general;
+                }
+            }
+        }
+
+        return $previous;
+    }),
+];

--- a/files/plugin-EnvironmentVariables-5.0.2/plugin.json
+++ b/files/plugin-EnvironmentVariables-5.0.2/plugin.json
@@ -1,0 +1,25 @@
+{
+    "name": "EnvironmentVariables",
+    "description": "Allows you to specify Matomo config in environment variables instead of the config file.",
+    "version": "5.0.2",
+    "theme": false,
+    "require": {
+        "matomo": ">=5.0.0-b1,<6.0.0-b1"
+    },
+    "authors": [
+        {
+            "name": "Matomo",
+            "email": "hello@matomo.org",
+            "homepage": "https://matomo.org"
+        }
+    ],
+    "support": {
+        "email": "",
+        "issues": "https://github.com/matomo-org/plugin-EnvironmentVariables/issues/",
+        "forum": "https://forum.matomo.org"
+    },
+    "homepage": "https://matomo.org",
+    "license": "GPL v3+",
+    "keywords": ["php", "environment", "variables", "configuration"],
+    "category": "database"
+}


### PR DESCRIPTION
### What does this PR do?

* Upgrade the Matomo Docker container from version 5.1.1 to 5.1.2
* Upgrade the EnvironmentVariables plugin from version 5.0.0 to 5.0.2

### Helpful background context

This was requested via JSM by UXWS. See [release notes](https://matomo.org/changelog/matomo-5-1-2/) for more details from Matomo.

### How can a reviewer manually see the effects of these changes?

Log in to the web UI as Superuser and verify that the reported version is 5.1.2.

Screenshot from Dev1 instance after deploying the new container:
<img width="877" alt="image" src="https://github.com/user-attachments/assets/862aa5a3-784d-4350-99aa-1485de7ebc1b">


### Includes new or updated dependencies?

**YES**

* Includes an update to the EnvironmentVariables plugin.
* **Requires** a database upgrade after deploying the new container!


### What are the relevant tickets?

* [INFRA-483](https://mitlibraries.atlassian.net/browse/INFRA-483)

### Developer

- [n/a] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes


[INFRA-483]: https://mitlibraries.atlassian.net/browse/INFRA-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ