### PR TITLE
Activate SearchEngineKeywordsPerformance Plugin

### DIFF
--- a/files/config.ini.php
+++ b/files/config.ini.php
@@ -107,6 +107,7 @@ Plugins[] = "TagManager"
 Plugins[] = "CustomVariables"
 Plugins[] = "EnvironmentVariables"
 Plugins[] = "HeatmapSessionRecording"
+Plugins[] = "SearchEngineKeywordsPerformance"
 Plugins[] = "UsersFlow"
 
 
@@ -183,6 +184,7 @@ PluginsInstalled[] = "VisitorInterest"
 PluginsInstalled[] = "VisitsSummary"
 PluginsInstalled[] = "WebsiteMeasurable"
 PluginsInstalled[] = "Widgetize"
+PluginsInstalled[] = "SearchEngineKeywordsPerformance"
 
 [HeatmapSessionRecording]
 add_tracking_code_only_when_needed = 1


### PR DESCRIPTION
### What does this PR do?

* Add the SearchEngineKeywordsPerformance to the list of installed plugins
* Add the SearchEngineKeywordsPerformance to the list of active plugins

### Helpful background context

The files are in place in the container across all three environments and the `./console plugin:activate` command has been run once in all three environments (which preps the database). Now we need to ensure that any container redeploys maintain the active status for this plugin.

### How can a reviewer manually see the effects of these changes?

Check the version of Matomo running in Dev1. The plugin should be installed and listed as "Active" in the list of plugins. I have temporarily added our license key to the dev-matomo instance for this purpose. Once this PR is approved, I will remove the license key from Dev (since we are technically only allowed to use the key on two instances of Matomo).

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

* [INFRA-558](https://mitlibraries.atlassian.net/browse/INFRA-558)

### Developer

- [n/a] All new ENV is documented in README (or there is none)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes


[INFRA-558]: https://mitlibraries.atlassian.net/browse/INFRA-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ